### PR TITLE
helm: add support for workflow webhook

### DIFF
--- a/chart/prometheus-msteams/cardWorkflow.tmpl
+++ b/chart/prometheus-msteams/cardWorkflow.tmpl
@@ -1,0 +1,81 @@
+{{ define "teams.card" }}
+{
+  "type":"message",
+  "attachments":[
+  {
+      "contentType":"application/vnd.microsoft.card.adaptive",
+      "contentUrl":null,
+      "content":{
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.2",
+        "backgroundImage": {
+            {{- $color := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAAAAABqswrmAAAAEElEQVR42mJogEBAAAAA//8ICAIBsBUbsAAAAABJRU5ErkJggg==" }}
+            {{- if eq .Status "resolved" -}}
+              {{- $color = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAIAAADAusJtAAAAEklEQVR42mLQPa6LjAEBAAD//yQwBIUSNPBIAAAAAElFTkSuQmCC" -}}
+            {{- else if eq .Status "firing" -}}
+              {{- if eq .CommonLabels.severity "critical" -}}
+              {{- $color = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAIAAADAusJtAAAAEklEQVR42mLokZJCxoAAAAD//xnYAwEPSWrRAAAAAElFTkSuQmCC" }}
+              {{- else if eq .CommonLabels.severity "warning" -}}
+              {{- $color = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAIAAADAusJtAAAAEklEQVR42mL4v5QBGQMCAAD//ziMBpHr7M3UAAAAAElFTkSuQmCC" }}
+              {{- end -}}
+            {{- end -}}
+            "url": "{{- $color -}}",
+            "fillMode": "RepeatHorizontally"
+        },
+        "body": [
+            {
+              "type": "TextBlock",
+              "text": "Prometheus Alert ({{ .Status | title }})",
+              "weight": "bolder",
+              "size": "medium"
+            },
+            {
+              "type": "TextBlock",
+              "text": "{{- if eq .CommonAnnotations.summary "" -}}
+              {{- if eq .CommonAnnotations.message "" -}}
+                {{- if eq .CommonLabels.alertname "" -}}
+                  Prometheus Alert
+                {{- else -}}
+                  {{- .CommonLabels.alertname -}}
+                {{- end -}}
+              {{- else -}}
+                {{- .CommonAnnotations.message -}}
+              {{- end -}}
+          {{- else -}}
+              {{- .CommonAnnotations.summary -}}
+          {{- end -}}",
+              "wrap": true
+            },
+            {{$externalUrl := .ExternalURL}}
+            {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
+            {
+              "type": "TextBlock",
+              "text": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})",
+              "wrap": true
+            },
+            {
+              "type": "FactSet",
+              "facts": [
+                {{- range $key, $value := $alert.Annotations }}
+                {
+                  {{- if ne $key "description" -}}
+                    "title": "{{ $key }}",
+                    "value": "{{ $value }}"
+                  {{- end -}}
+                },
+                {{- end -}}
+                {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}
+                {
+                  "title": "{{ $key }}",
+                  "value": "{{ $value }}"
+                }
+                {{- end }}
+              ]
+            }
+          {{- end }}
+        ]
+      }
+  }]
+}
+{{ end }}

--- a/chart/prometheus-msteams/templates/configMapTemplate.yaml
+++ b/chart/prometheus-msteams/templates/configMapTemplate.yaml
@@ -8,7 +8,11 @@ binaryData:
 {{- if .Values.customCardTemplate }}
 {{ .Values.customCardTemplate | b64enc | indent 4 }}
 {{- else }}
+  {{- if .Values.workflowWebhook}}
+{{ .Files.Get "cardWorkflow.tmpl" | b64enc | indent 4 }}
+  {{- else }}
 {{ .Files.Get "card.tmpl" | b64enc | indent 4 }}
+  {{- end }}
 {{- end }}
 {{- range $index, $customCardTemplate := .Values.connectorsWithCustomTemplates }}
 {{- if hasKey $customCardTemplate "template_file" }}

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           args:
             - -config-file=/etc/config/connectors.yaml
             - -template-file={{ .Values.templateFile }}
+            - -workflow-webhook={{ .Values.workflowWebhook }}
           {{- with .Values.container.additionalArgs }}
 {{ toYaml . | indent 12 }}
           {{- end}}

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -89,3 +89,6 @@ envFrom: {}
 #       name: my-prometheus-msteams-env-secret
 #   - configMapRef:
 #       name: my-prometheus-msteams-env-cm
+
+# Whether to use the new Microsoft Workflow webhooks
+workflowWebhook: false


### PR DESCRIPTION
In order to have correct deployment for the teams workflow webhook it is important to use the correct card templates. This change adds a value "workflowWebhook" which can be toggled in the same way as the main application to select the workflow webhook behavior.

Used this helm chart to deploy to a Kubernetes cluster and it was working well there.